### PR TITLE
Fixes test using environment dependent path

### DIFF
--- a/SikuliSharp.Tests/Unit/SikuliScriptProcessFactoryTests.cs
+++ b/SikuliSharp.Tests/Unit/SikuliScriptProcessFactoryTests.cs
@@ -28,12 +28,13 @@ namespace SikuliSharp.Tests.Unit
 			processFactory.Start(processFactory.GetSikuliVersion());
 		}
 
-		[Test, ExpectedException(typeof(NotSupportedException), ExpectedMessage = @"Could not find a known Sikuli version in SIKULI_HOME: ""C:\Temp""")]
+		[Test]
 		public void ThrowsIfSikuliHomeIsSetAndFileDoesNotExist()
 		{
-			Environment.SetEnvironmentVariable("SIKULI_HOME", @"C:\Temp", EnvironmentVariableTarget.Process);
+			Environment.SetEnvironmentVariable("SIKULI_HOME", "%USERPROFILE%", EnvironmentVariableTarget.Process);
 			var processFactory = new SikuliScriptProcessFactory();
-			processFactory.Start(processFactory.GetSikuliVersion());
+			var ex = Assert.Throws<NotSupportedException>(() => processFactory.Start(processFactory.GetSikuliVersion()));
+			Assert.That(ex.Message.StartsWith("Could not find a known Sikuli version in SIKULI_HOME"));
 		}
 	}
 }

--- a/SikuliSharp/SikuliScriptProcessFactory.cs
+++ b/SikuliSharp/SikuliScriptProcessFactory.cs
@@ -18,6 +18,8 @@ namespace SikuliSharp
 		{
 			var sikuliHome = MakeEmptyNull(Environment.GetEnvironmentVariable("SIKULI_HOME"));
 			if (sikuliHome == null) throw new Exception("Environment variable SIKULI_HOME not set. Please verify that Sikuli is installed (sikuli-script.jar must be present) and create a SIKULI_HOME environment variable. You may need to restart your command prompt or IDE.");
+
+			sikuliHome = Environment.ExpandEnvironmentVariables(sikuliHome);
 			var jarFiles = Directory.GetFiles(sikuliHome, "*.jar");
 			var jarFilenames = jarFiles.Select(path => Path.GetFileName(path)).ToArray();
 


### PR DESCRIPTION
The test ThrowsIfSikuliHomeIsSetAndFileDoesNotExist is using the hardcoded path C:\Temp. Not everyone has a C drive (default Windows drive letter can be changed) and not everyone has a folder Temp inside.
I used the environment variable %USERPROFILE% for SIKULI_HOME and made the GetSikuliVersion method capable of expanding environment variable found in SIKULI_HOME path.
I then removed the ExpectedException attribute (considered a bad practice in NUnit world :)) from the NUnit test and used Assert.Throws() instead to be able to Assert only part of the exception message.