### PR TITLE
Fixes test using culture dependent data format

### DIFF
--- a/SikuliSharp.Tests/Unit/SikuliSessionTests.cs
+++ b/SikuliSharp.Tests/Unit/SikuliSessionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -31,7 +32,7 @@ namespace SikuliSharp.Tests.Unit
 				yield return new CommandTestData
 				{
 					Timeout = 15.8518352508545f,
-					ExpectedCommand = "print \"SIKULI#: YES\" if exists(::PATTERN::, 10.5679) else \"SIKULI#: NO\"",
+					ExpectedCommand = "print \"SIKULI#: YES\" if exists(::PATTERN::, " + string.Format(Thread.CurrentThread.CurrentCulture, "{0:00.0000}", 10.56789f) + ") else \"SIKULI#: NO\"",
 					Method = (session, pattern) => session.Exists(pattern, 10.56789f)
 				};
 


### PR DESCRIPTION
On my environment which is using fr-FR culture format the test fails because 10.5679 is found in the command instead of 10,5679. And I didn't checked but I suppose 10,5679 was expected because the float parameter 10.56789f passed to the method Exists is parsed into the current culture.